### PR TITLE
#3 Subscribe button w/Klaviyo integration

### DIFF
--- a/assets/css/subscribe.css
+++ b/assets/css/subscribe.css
@@ -45,7 +45,7 @@
 .subscribe-notify {
     display: block;
     position: absolute;
-    top: 75px;
+    top: 80px;
     font-size: .9rem;
     color: red;
     margin-left: 20px;

--- a/assets/css/subscribe.css
+++ b/assets/css/subscribe.css
@@ -44,11 +44,11 @@
 .subscribe-button:hover {background-color: #00e0b7;border-color: transparent;color: white;}
 .subscribe-notify {
     display: block;
-    position: relative;
+    position: absolute;
+    top: 75px;
     font-size: .9rem;
     color: red;
     margin-left: 20px;
-    padding-bottom: 50px;
 }
 .subscribe-notify-success {
     color: #00edb1;

--- a/assets/css/subscribe.css
+++ b/assets/css/subscribe.css
@@ -154,19 +154,19 @@ textarea:focus, input:focus{
 
 .subscribe-button-top:hover {background-color: #00e0b7;border-color: transparent;color: white;}
 .subscribe-notify-top {
-    display: none;
-    position: relative;
+    position: absolute;
+    top: 50px;
     font-size: .9rem;
     color: white;
-    margin-left: 20px;
-    padding-bottom: 50px;
+    max-width: 300px;
+    margin-left: 10px;
 }
 .subscribe-notify-success-top {
     color: #0a0a0a;
     display: block;
     background-color: #00edb1;
     border-radius: 1000px;
-    width: 80%;
+    width: 90%;
     padding: 3px;
     text-align: center;
 }

--- a/index.html
+++ b/index.html
@@ -791,18 +791,33 @@ var timer = setInterval(function(){
                         <div class="minimal-feature">
                             <h2 class="title minimal-title bold-text light-text no-margin subscribe-title">Stay Tuned!</h2>
 
-                            <div class="control subscribe-form">
-                            <input type="text" class="subscribe-input" placeholder="Enter your email">
-                            <button type="button" class="button input-button subscribe-button">OK</button>
-                           
+                            <form id="token_signup" class="control subscribe-form-top klaviyo_gdpr_embed_JNzCxr" action="https://manage.kmail-lists.com/subscriptions/subscribe?g=JNzCxr" data-ajax-submit="https://manage.kmail-lists.com/ajax/subscriptions/subscribe?g=JNzCxr" method="GET" target="_blank" novalidate="novalidate">
+                                <input type="hidden" name="g" value="JNzCxr">
+                                <input type="text" name="email" id="k_id_email" class="subscribe-input-top" placeholder="Enter your email">
+                                <div class="klaviyo_form_actions">
+                                    <button type="submit" class="button input-button subscribe-button-top">OK</button>
+                                </div>
+                                <div class="success_message subscribe-notify-top subscribe-notify-success-top" style="display: none;">
+                                    Thank you! Keep an eye out for updates!
+                                </div>
+                                <div class="error_message subscribe-notify-top subscribe-notify-failure-top" style="display: none;">
+                                    Not a valid email. Try again.
+                                </div>
+                            </form>
+                            <script type="text/javascript" src="https://www.klaviyo.com/media/js/public/klaviyo_subscribe.js"></script>
+                            <script type="text/javascript">
+                                KlaviyoSubscribe.attachToForms('#token_signup', {
+                                    custom_error_message: true,
+                                    custom_success_message: true,
+                                    extra_properties: {
+                                        $source: 'MultichainVenturesTokenSubscribe',
+                                        Brand: 'MultichainVentures',
+                                    }
+                                });
+                            </script>
 
 
                         </div>
-                         
-                            <div class="subscribe-notify">
-                            <p class="subscribe-notify-success">Thank you! Keep an eye out for updates!</a></p>
-                            <p class="subscribe-notify-failure">Not a valid email. Try again.</a></p>
-                            </div>
                         </div>
                     </div>
                     <!-- /CTA content -->

--- a/index.html
+++ b/index.html
@@ -492,18 +492,30 @@ Learn More                                </a> -->
                         <div class="minimal-feature">
                             <h2 class="title minimal-title bold-text light-text no-margin subscribe-title-top has-text-centered">Subscribe to learn more.</h2>
 
-                            <div class="control subscribe-form-top">
-                            <input type="text" class="subscribe-input-top" placeholder="Enter your email">
-                            <button type="button" class="button input-button subscribe-button-top">OK</button>
-
-
-
-                        </div>
-
-                            <div class="subscribe-notify-top">
-                            <p class="subscribe-notify-success-top">Thank you! Keep an eye out for updates!</a></p>
-                            <p class="subscribe-notify-failure-top">Not a valid email. Try again.</a></p>
-                            </div>
+                            <form id="email_signup" class="control subscribe-form-top klaviyo_gdpr_embed_JNzCxr" action="https://manage.kmail-lists.com/subscriptions/subscribe?g=JNzCxr" data-ajax-submit="https://manage.kmail-lists.com/ajax/subscriptions/subscribe?g=JNzCxr" method="GET" target="_blank" novalidate="novalidate">
+                                <input type="hidden" name="g" value="JNzCxr">
+                                <input type="text" name="email" id="k_id_email" class="subscribe-input-top" placeholder="Enter your email">
+                                <div class="klaviyo_form_actions">
+                                    <button type="submit" class="button input-button subscribe-button-top">OK</button>
+                                </div>
+                                <div class="success_message subscribe-notify-top subscribe-notify-success-top" style="display: none;">
+                                    Thank you! Keep an eye out for updates!
+                                </div>
+                                <div class="error_message subscribe-notify-top subscribe-notify-failure-top" style="display: none;">
+                                    Not a valid email. Try again.
+                                </div>
+                            </form>
+                            <script type="text/javascript" src="https://www.klaviyo.com/media/js/public/klaviyo_subscribe.js"></script>
+                            <script type="text/javascript">
+                                KlaviyoSubscribe.attachToForms('#email_signup', {
+                                    custom_error_message: true,
+                                    custom_success_message: true,
+                                    extra_properties: {
+                                        $source: 'MultichainVenturesSubscribe',
+                                        Brand: 'MultichainVentures',
+                                    }
+                                });
+                            </script> 
                         </div>
                     </div>
 <!-- End Subscribe Block -->

--- a/index.html
+++ b/index.html
@@ -791,11 +791,11 @@ var timer = setInterval(function(){
                         <div class="minimal-feature">
                             <h2 class="title minimal-title bold-text light-text no-margin subscribe-title">Stay Tuned!</h2>
 
-                            <form id="token_signup" class="control subscribe-form-top klaviyo_gdpr_embed_JNzCxr" action="https://manage.kmail-lists.com/subscriptions/subscribe?g=JNzCxr" data-ajax-submit="https://manage.kmail-lists.com/ajax/subscriptions/subscribe?g=JNzCxr" method="GET" target="_blank" novalidate="novalidate">
+                            <form id="token_signup" class="control subscribe-form klaviyo_gdpr_embed_JNzCxr" action="https://manage.kmail-lists.com/subscriptions/subscribe?g=JNzCxr" data-ajax-submit="https://manage.kmail-lists.com/ajax/subscriptions/subscribe?g=JNzCxr" method="GET" target="_blank" novalidate="novalidate">
                                 <input type="hidden" name="g" value="JNzCxr">
-                                <input type="text" name="email" id="k_id_email" class="subscribe-input-top" placeholder="Enter your email">
+                                <input type="text" name="email" id="k_id_email" class="subscribe-input" placeholder="Enter your email">
                                 <div class="klaviyo_form_actions">
-                                    <button type="submit" class="button input-button subscribe-button-top">OK</button>
+                                    <button type="submit" class="button input-button subscribe-button">OK</button>
                                 </div>
                                 <div class="success_message subscribe-notify subscribe-notify-success" style="display: none;">
                                     Thank you! Keep an eye out for updates!

--- a/index.html
+++ b/index.html
@@ -797,10 +797,10 @@ var timer = setInterval(function(){
                                 <div class="klaviyo_form_actions">
                                     <button type="submit" class="button input-button subscribe-button-top">OK</button>
                                 </div>
-                                <div class="success_message subscribe-notify-top subscribe-notify-success-top" style="display: none;">
+                                <div class="success_message subscribe-notify subscribe-notify-success" style="display: none;">
                                     Thank you! Keep an eye out for updates!
                                 </div>
-                                <div class="error_message subscribe-notify-top subscribe-notify-failure-top" style="display: none;">
+                                <div class="error_message subscribe-notify subscribe-notify-failure" style="display: none;">
                                     Not a valid email. Try again.
                                 </div>
                             </form>


### PR DESCRIPTION
### Changes
Resolves #3 

- Adds Klaviyo support to the `Subscribe` form
- Updated notification text styles

NOTES:
- Klaviyo uses dynamic protocol links in their scripts (i think to avoid mixed content delivery errors), so these changes can't be tested by simply opening the HTML file in a browser (that would result in their urls all starting with `file://`) ... in order to test this properly, follow these simple steps:
  - run `npm i -g http-server`
  - from the root directory, run `http-server`
  - use one of the links generated to access `index.html`
- You should be able to verify everything is working by receiving a confirmation email in your inbox from Multichain Ventures after subscribing

### Checklist
- [x] UAT